### PR TITLE
added toggleable global auth

### DIFF
--- a/api/InventaAPI/Controllers/ServiceProxyController.cs
+++ b/api/InventaAPI/Controllers/ServiceProxyController.cs
@@ -6,13 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 
 namespace DFDSServiceAPI.Controllers
 {
     [Produces("application/json")]
     [Route("api/[controller]")]
-    [Authorize(AuthenticationSchemes = "Bearer")]
     [ApiController]
     public class ServiceProxyController : Controller
     {

--- a/api/InventaAPI/InventaAPI.csproj
+++ b/api/InventaAPI/InventaAPI.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="5.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.3" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="4.2.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.7.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>


### PR DESCRIPTION
This PR makes authentication global so that it can be toggled on and off, useful for sandboxes, experimenting etc without a hard requirement on Azure AD. If any controller actions need to always be anonymous, the `[AllowAnonymous]` annotation can be added